### PR TITLE
Expand .gitignore to ignore LibriSpeech data at any path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,16 +223,18 @@ __marimo__/
 .claudeignore
 
 # LibriSpeech audio data (large binary files — never commit)
-data/LibriSpeech*/
-data/*.flac
-data/*.wav
-data/*.mp3
+LibriSpeech*/
+*.flac
+*.wav
+*.mp3
+
+# LibriSpeech alignment data (large, download separately)
+LibriSpeech-Alignments/
+LibriSpeech-Alignments.zip
+LibriSpeech.zip
 
 # Background literature PDFs (cite with links in README instead)
 BackgroundLiterature/
-
-# Forced alignment TextGrids (large, download separately)
-data/alignments/
 
 # Embedding cache and model outputs (large NPZ files)
 results/cache/


### PR DESCRIPTION
## Summary

- Removes `data/` prefix from LibriSpeech audio patterns so they match at any depth
- Drops stale `data/alignments/` entry
- Adds `LibriSpeech-Alignments/`, `LibriSpeech-Alignments.zip`, and `LibriSpeech.zip`

## Testing

Verified with `git check-ignore` that all patterns match both inside `data/` and at
the repo root — zips, directories, and audio files (.flac, .wav) all correctly ignored.