### PR TITLE
Extend collect_bundle cache to include aligned phoneme and pitch features

### DIFF
--- a/encode/collect.py
+++ b/encode/collect.py
@@ -1,11 +1,11 @@
 """
 Encode utterances with both codecs, align phoneme/speaker/pitch labels,
-and cache per-utterance embeddings as NPZ files to avoid re-encoding on
-subsequent runs.
+and cache per-utterance embeddings, phonemes, and pitches as NPZ files to
+avoid re-encoding and re-extracting features on subsequent runs.
 """
 
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, TypedDict
+from typing import List, Optional, Tuple, TypedDict
 
 import numpy as np
 import torchaudio
@@ -28,7 +28,7 @@ class Bundle(TypedDict):
     embeddings: List[np.ndarray]   # 8 arrays, each shape (N_tokens, embed_dim)
     phonemes:   np.ndarray         # (N_tokens,) string phoneme labels
     speakers:   np.ndarray         # (N_tokens,) string speaker IDs
-    pitch:      np.ndarray         # (N_tokens,) float32 Hz; NaN for unvoiced
+    pitches:    np.ndarray         # (N_tokens,) float32 Hz; NaN for unvoiced
 
 
 # ── Alignment ──────────────────────────────────────────────────────────────────
@@ -49,22 +49,87 @@ def _cache_path(cache_dir: Path, codec: str, utterance_id: str) -> Path:
 
 
 def _load_cached(
-    cache_dir: Path, codec: str, utterance_id: str
-) -> Optional[List[np.ndarray]]:
-    """Return 8 layer-embedding arrays from disk, or None if not cached yet."""
-    p = _cache_path(cache_dir, codec, utterance_id)
-    if not p.exists():
+    cache_dir: Path, codec: str, utterance_id: str,
+) -> Optional[Tuple[List[np.ndarray], Optional[np.ndarray], Optional[np.ndarray]]]:
+    """Return (embeddings, phonemes, pitches) from disk, or None if not cached.
+    phonemes and pitches are None when absent from an older cache file."""
+    path = _cache_path(cache_dir, codec, utterance_id)
+    if not path.exists():
         return None
-    with np.load(p) as data:
-        return [data[f"layer_{i}"] for i in range(NUM_LAYERS)]
+    with np.load(path, allow_pickle=False) as data:
+        embeddings = [data[f"layer_{i}"] for i in range(NUM_LAYERS)]
+        phonemes   = data["phonemes"] if "phonemes" in data else None
+        pitches    = data["pitches"] if "pitches" in data else None
+    return embeddings, phonemes, pitches
 
 
 def _save_cache(
-    cache_dir: Path, codec: str, utterance_id: str, embeddings: List[np.ndarray]
+    cache_dir: Path, codec: str, utterance_id: str,
+    embeddings: List[np.ndarray],
+    phonemes: np.ndarray,
+    pitches: np.ndarray,
 ) -> None:
-    p = _cache_path(cache_dir, codec, utterance_id)
-    p.parent.mkdir(parents=True, exist_ok=True)
-    np.savez(p, **{f"layer_{i}": emb for i, emb in enumerate(embeddings)})
+    path = _cache_path(cache_dir, codec, utterance_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cache_fields = {f"layer_{i}": emb for i, emb in enumerate(embeddings)}
+    cache_fields["phonemes"] = phonemes
+    cache_fields["pitches"] = pitches
+    np.savez(file=path, **cache_fields)  # pyright: ignore[reportArgumentType]
+
+
+# ── Per-utterance feature helpers ─────────────────────────────────────────────
+
+def _extract_features(
+    embeddings: List[np.ndarray],
+    audio,
+    sr: int,
+    phone_intervals,
+    token_rate: float,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Return (phonemes, pitches) aligned to the codec's token grid."""
+    num_tokens = embeddings[0].shape[0]
+    phones = np.array(phoneme_labels_for_tokens(phone_intervals, token_rate, num_tokens))
+    pitches = extract_pitch_hz(audio, sr, token_rate, num_tokens)
+    return phones, pitches
+
+
+def _get_utterance_data(
+    codec: str,
+    cached: Optional[Tuple[List[np.ndarray], Optional[np.ndarray], Optional[np.ndarray]]],
+    cache_dir: Path,
+    utterance_id: str,
+    encode_fn,
+    model,
+    audio,
+    sr,
+    phone_intervals,
+    token_rate: float,
+) -> Optional[Tuple[List[np.ndarray], np.ndarray, np.ndarray]]:
+    """Resolve (embeddings, phonemes, pitches) for one utterance and codec.
+
+    Handles three cases:
+        - No cache: encode audio, extract features, save everything.
+        - Partial cache (old file missing phonemes or pitches): reuse embeddings,
+          extract features from audio, re-save the updated cache.
+        - Full cache: return cached data immediately without touching audio.
+
+    Returns None if encoding fails; the caller should skip the utterance.
+    """
+    if cached is None:
+        try:
+            embeddings, _ = encode_fn(model, audio, sr)
+        except Exception as e:
+            print(f"  [{codec}] {utterance_id}: {e}")
+            return None
+        phones, pitches = _extract_features(embeddings, audio, sr, phone_intervals, token_rate)
+        _save_cache(cache_dir, codec, utterance_id, embeddings, phones, pitches)
+        return embeddings, phones, pitches
+
+    embeddings, phones, pitches = cached
+    if phones is None or pitches is None:
+        phones, pitches = _extract_features(embeddings, audio, sr, phone_intervals, token_rate)
+        _save_cache(cache_dir, codec, utterance_id, embeddings, phones, pitches)
+    return embeddings, phones, pitches
 
 
 # ── Main collection function ───────────────────────────────────────────────────
@@ -84,15 +149,16 @@ def collect_bundle(
       - Its TextGrid alignment file is missing.
       - Either codec raises an exception during encoding.
 
-    Embeddings are saved to cache_dir/{codec}/{utterance_id}.npz after encoding
-    so re-runs load from disk instead of re-encoding.
+    Embeddings, phonemes, and pitches are saved to
+    cache_dir/{codec}/{utterance_id}.npz after the first run so subsequent
+    runs load everything from disk without re-encoding or re-extracting.
 
     Args:
         utterance_entries: List of (flac_path, speaker_id, utterance_id).
         encodec_model:     Loaded EnCodec model.
         st_model:          Loaded SpeechTokenizer model.
         alignments_root:   Root of TextGrid alignment files.
-        cache_dir:         Directory for NPZ embedding cache.
+        cache_dir:         Directory for NPZ cache.
         max_utterances:    Stop after this many utterances (0 = no limit).
 
     Returns:
@@ -100,81 +166,80 @@ def collect_bundle(
             "embeddings": List of 8 ndarrays, each shape (N_tokens, embed_dim)
             "phonemes":   ndarray of shape (N_tokens,), dtype str
             "speakers":   ndarray of shape (N_tokens,), dtype str
-            "pitch":      ndarray of shape (N_tokens,), float32 (NaN = unvoiced)
+            "pitches":      ndarray of shape (N_tokens,), float32 (NaN = unvoiced)
     """
-    enc_layers = [[] for _ in range(NUM_LAYERS)]
-    st_layers  = [[] for _ in range(NUM_LAYERS)]
-    enc_phones: List[str] = []
-    st_phones:  List[str] = []
-    enc_spk:    List[str] = []
-    st_spk:     List[str] = []
-    enc_pitch:  List[np.ndarray] = []
-    st_pitch:   List[np.ndarray] = []
+    encdc_layers:   List[List[np.ndarray]] = [[] for _ in range(NUM_LAYERS)]
+    st_layers:      List[List[np.ndarray]] = [[] for _ in range(NUM_LAYERS)]
+    encdc_phonemes: List[np.ndarray] = []
+    st_phonemes:    List[np.ndarray] = []
+    encdc_speakers: List[str] = []
+    st_speakers:    List[str] = []
+    encdc_pitches:  List[np.ndarray] = []
+    st_pitches:     List[np.ndarray] = []
 
     count = 0
     for flac_path, speaker_id, utterance_id in tqdm(utterance_entries, desc="Collecting"):
         if max_utterances > 0 and count >= max_utterances:
             break
 
-        # Alignment must exist before we bother loading audio
+        # Alignment must exist before we try loading audio
         tg_path = _alignment_path(alignments_root, utterance_id)
         phone_intervals = load_textgrid_phones(str(tg_path))
         if not phone_intervals:
             continue
 
-        audio, sr = torchaudio.load(flac_path)
+        encdc_cached = _load_cached(cache_dir, "encodec", utterance_id)
+        st_cached = _load_cached(cache_dir, "speechtokenizer", utterance_id)
 
-        # ── EnCodec ────────────────────────────────────────────────────────
-        enc_embs = _load_cached(cache_dir, "encodec", utterance_id)
-        if enc_embs is None:
-            try:
-                enc_embs, _ = encodec_encode(encodec_model, audio, sr)
-            except Exception as e:
-                print(f"  [EnCodec] {utterance_id}: {e}")
-                continue
-            _save_cache(cache_dir, "encodec", utterance_id, enc_embs)
+        need_audio = (
+            encdc_cached is None or encdc_cached[1] is None or encdc_cached[2] is None or
+            st_cached is None or st_cached[1] is None or st_cached[2] is None
+        )
+        audio, sr = torchaudio.load(flac_path) if need_audio else (None, None)
 
-        # ── SpeechTokenizer ────────────────────────────────────────────────
-        st_embs = _load_cached(cache_dir, "speechtokenizer", utterance_id)
-        if st_embs is None:
-            try:
-                st_embs, _ = st_encode(st_model, audio, sr)
-            except Exception as e:
-                print(f"  [SpeechTokenizer] {utterance_id}: {e}")
-                continue   # skip whole utterance if either codec fails
-            _save_cache(cache_dir, "speechtokenizer", utterance_id, st_embs)
+        encdc_result = _get_utterance_data(
+            "encodec", encdc_cached, cache_dir, utterance_id,
+            encodec_encode, encodec_model, audio, sr, phone_intervals, ENCODEC_TOKEN_RATE,
+        )
+        if encdc_result is None:
+            continue
 
-        enc_ntok = enc_embs[0].shape[0]
-        st_ntok  = st_embs [0].shape[0]
+        st_result = _get_utterance_data(
+            "speechtokenizer", st_cached, cache_dir, utterance_id,
+            st_encode, st_model, audio, sr, phone_intervals, ST_TOKEN_RATE,
+        )
+        if st_result is None:
+            continue
 
-        # Align phoneme labels and extract pitch for each codec's token grid
-        enc_phones.extend(phoneme_labels_for_tokens(phone_intervals, ENCODEC_TOKEN_RATE, enc_ntok))
-        st_phones .extend(phoneme_labels_for_tokens(phone_intervals, ST_TOKEN_RATE,      st_ntok))
-        enc_spk   .extend([speaker_id] * enc_ntok)
-        st_spk    .extend([speaker_id] * st_ntok)
-        enc_pitch .append(extract_pitch_hz(audio, sr, ENCODEC_TOKEN_RATE, enc_ntok))
-        st_pitch  .append(extract_pitch_hz(audio, sr, ST_TOKEN_RATE,      st_ntok))
+        encdc_embeddings, encdc_phone_labels, encdc_pitch_values = encdc_result
+        st_embeddings, st_phone_labels, st_pitch_values = st_result
+
+        encdc_phonemes.append(encdc_phone_labels)
+        st_phonemes.append(st_phone_labels)
+        encdc_speakers.extend([speaker_id] * encdc_embeddings[0].shape[0])
+        st_speakers.extend([speaker_id] * st_embeddings[0].shape[0])
+        encdc_pitches.append(encdc_pitch_values)
+        st_pitches.append(st_pitch_values)
 
         for i in range(NUM_LAYERS):
-            enc_layers[i].append(enc_embs[i])
-            st_layers [i].append(st_embs [i])
+            encdc_layers[i].append(encdc_embeddings[i])
+            st_layers[i].append(st_embeddings[i])
 
         count += 1
 
-    def _bundle(layers, phones, spk, pitch_parts) -> Bundle:
+    def _bundle(layers, phonemes, speakers, pitches) -> Bundle:
         if not layers[0]:
             raise ValueError(
                 "No utterances were collected. Check alignment files and codec errors before training probes."
             )
         return Bundle(
             embeddings=[np.concatenate(layers[i], axis=0) for i in range(NUM_LAYERS)],
-            phonemes=np.array(phones),
-            speakers=np.array(spk),
-            pitch=(np.concatenate(pitch_parts) if pitch_parts
-                   else np.array([], dtype=np.float32)),
+            phonemes=np.concatenate(phonemes),
+            speakers=np.array(speakers),
+            pitches=(np.concatenate(pitches) if pitches else np.array([], dtype=np.float32)),
         )
 
     return (
-        _bundle(enc_layers, enc_phones, enc_spk, enc_pitch),
-        _bundle(st_layers,  st_phones,  st_spk,  st_pitch),
+        _bundle(encdc_layers, encdc_phonemes, encdc_speakers, encdc_pitches),
+        _bundle(st_layers, st_phonemes, st_speakers, st_pitches),
     )

--- a/encode/collect.py
+++ b/encode/collect.py
@@ -63,6 +63,12 @@ def _load_cached(
     return embeddings, phonemes, pitches
 
 
+def _cache_is_complete(
+    cached: Optional[Tuple[List[np.ndarray], Optional[np.ndarray], Optional[np.ndarray]]],
+) -> bool:
+    return cached is not None and cached[1] is not None and cached[2] is not None
+
+
 def _save_cache(
     cache_dir: Path, codec: str, utterance_id: str,
     embeddings: List[np.ndarray],
@@ -71,10 +77,10 @@ def _save_cache(
 ) -> None:
     path = _cache_path(cache_dir, codec, utterance_id)
     path.parent.mkdir(parents=True, exist_ok=True)
-    cache_fields = {f"layer_{i}": emb for i, emb in enumerate(embeddings)}
-    cache_fields["phonemes"] = phonemes
-    cache_fields["pitches"] = pitches
-    np.savez(file=path, **cache_fields)  # pyright: ignore[reportArgumentType]
+    payload = {f"layer_{i}": emb for i, emb in enumerate(embeddings)}
+    payload["phonemes"] = phonemes
+    payload["pitches"] = pitches
+    np.savez(file=path, **payload)  # pyright: ignore[reportArgumentType]
 
 
 # ── Per-utterance feature helpers ─────────────────────────────────────────────
@@ -146,7 +152,8 @@ def collect_bundle(
     Encode utterances with EnCodec and SpeechTokenizer; align labels.
 
     Each utterance is skipped if:
-      - Its TextGrid alignment file is missing.
+            - Its TextGrid alignment file is missing and a cache entry still needs
+                aligned phoneme or pitch features.
       - Either codec raises an exception during encoding.
 
     Embeddings, phonemes, and pitches are saved to
@@ -166,7 +173,7 @@ def collect_bundle(
             "embeddings": List of 8 ndarrays, each shape (N_tokens, embed_dim)
             "phonemes":   ndarray of shape (N_tokens,), dtype str
             "speakers":   ndarray of shape (N_tokens,), dtype str
-            "pitches":      ndarray of shape (N_tokens,), float32 (NaN = unvoiced)
+            "pitches":    ndarray of shape (N_tokens,), float32 (NaN = unvoiced)
     """
     encdc_layers:   List[List[np.ndarray]] = [[] for _ in range(NUM_LAYERS)]
     st_layers:      List[List[np.ndarray]] = [[] for _ in range(NUM_LAYERS)]
@@ -182,19 +189,18 @@ def collect_bundle(
         if max_utterances > 0 and count >= max_utterances:
             break
 
-        # Alignment must exist before we try loading audio
-        tg_path = _alignment_path(alignments_root, utterance_id)
-        phone_intervals = load_textgrid_phones(str(tg_path))
-        if not phone_intervals:
-            continue
-
         encdc_cached = _load_cached(cache_dir, "encodec", utterance_id)
         st_cached = _load_cached(cache_dir, "speechtokenizer", utterance_id)
+        needs_alignment = not (_cache_is_complete(encdc_cached) and _cache_is_complete(st_cached))
 
-        need_audio = (
-            encdc_cached is None or encdc_cached[1] is None or encdc_cached[2] is None or
-            st_cached is None or st_cached[1] is None or st_cached[2] is None
-        )
+        phone_intervals = None
+        if needs_alignment:
+            tg_path = _alignment_path(alignments_root, utterance_id)
+            phone_intervals = load_textgrid_phones(str(tg_path))
+            if not phone_intervals:
+                continue
+
+        need_audio = needs_alignment
         audio, sr = torchaudio.load(flac_path) if need_audio else (None, None)
 
         encdc_result = _get_utterance_data(

--- a/main.py
+++ b/main.py
@@ -94,7 +94,7 @@ def main():
         all_entries, args.eval_frac, SEED, split_path, force=args.force_resplit
     )
 
-    # ── Collect training data (embedding encode cache; align + pitch recomputed) ─
+    # ── Collect training data (embeddings, phonemes, and pitches all cached) ──────
     print(f"Collecting training data (cap={args.max_utterances or 'none'})...")
     enc_train, st_train = collect_bundle(
         train_entries, enc_model, st_model,
@@ -111,14 +111,14 @@ def main():
     print("Training EnCodec probes...")
     train_probes(
         enc_train["embeddings"], enc_train["phonemes"],
-        enc_train["speakers"],   enc_train["pitch"],
+        enc_train["speakers"],   enc_train["pitches"],
         codec_name="encodec", output_dir=str(probe_dir),
         label_encoders=label_encoders,
     )
     print("Training SpeechTokenizer probes...")
     train_probes(
         st_train["embeddings"], st_train["phonemes"],
-        st_train["speakers"],   st_train["pitch"],
+        st_train["speakers"],   st_train["pitches"],
         codec_name="speechtokenizer", output_dir=str(probe_dir),
         label_encoders=label_encoders,
     )
@@ -134,14 +134,14 @@ def main():
     print("Evaluating EnCodec probes...")
     enc_results = evaluate_probes(
         enc_eval["embeddings"], enc_eval["phonemes"],
-        enc_eval["speakers"],   enc_eval["pitch"],
+        enc_eval["speakers"],   enc_eval["pitches"],
         codec_name="encodec", probe_dir=str(probe_dir),
         label_encoders=label_encoders,
     )
     print("Evaluating SpeechTokenizer probes...")
     st_results = evaluate_probes(
         st_eval["embeddings"], st_eval["phonemes"],
-        st_eval["speakers"],   st_eval["pitch"],
+        st_eval["speakers"],   st_eval["pitches"],
         codec_name="speechtokenizer", probe_dir=str(probe_dir),
         label_encoders=label_encoders,
     )

--- a/tests/test_collect_cache.py
+++ b/tests/test_collect_cache.py
@@ -10,7 +10,7 @@ migrating it is tracked separately.
 import numpy as np
 import pytest
 
-from encode.collect import NUM_LAYERS, _get_utterance_data, _load_cached, _save_cache
+from encode.collect import NUM_LAYERS, _get_utterance_data, _load_cached, _save_cache, collect_bundle
 
 
 def _make_embeddings(num_tokens: int = 3, embed_dim: int = 4) -> list:
@@ -121,3 +121,42 @@ def test_get_utterance_data_backfills_missing_pitches(tmp_path, monkeypatch):
     assert pitches_after is not None
     np.testing.assert_array_equal(phones_after, expected_phones)
     np.testing.assert_array_equal(np.isnan(pitches_after), np.isnan(expected_pitches))
+
+
+def test_collect_bundle_uses_full_cache_without_alignment_or_audio(tmp_path, monkeypatch):
+    enc_embeddings = _make_embeddings(num_tokens=3)
+    st_embeddings = _make_embeddings(num_tokens=2)
+    enc_phonemes = np.array(["AH", "B", "SIL"])
+    st_phonemes = np.array(["D", "EH"])
+    enc_pitches = np.array([120.0, np.nan, 200.0], dtype=np.float32)
+    st_pitches = np.array([90.0, 95.0], dtype=np.float32)
+
+    _save_cache(tmp_path, "encodec", "100-200-0001", enc_embeddings, enc_phonemes, enc_pitches)
+    _save_cache(tmp_path, "speechtokenizer", "100-200-0001", st_embeddings, st_phonemes, st_pitches)
+
+    def _should_not_run(*_args, **_kwargs):
+        raise AssertionError("warm-cache path should not access uncached inputs")
+
+    monkeypatch.setattr("encode.collect.load_textgrid_phones", _should_not_run)
+    monkeypatch.setattr("encode.collect.torchaudio.load", _should_not_run)
+    monkeypatch.setattr("encode.collect.encodec_encode", _should_not_run)
+    monkeypatch.setattr("encode.collect.st_encode", _should_not_run)
+
+    enc_bundle, st_bundle = collect_bundle(
+        [("missing.flac", "speaker-1", "100-200-0001")],
+        encodec_model=None,
+        st_model=None,
+        alignments_root="missing-alignments",
+        cache_dir=tmp_path,
+    )
+
+    for i in range(NUM_LAYERS):
+        np.testing.assert_array_equal(enc_bundle["embeddings"][i], enc_embeddings[i])
+        np.testing.assert_array_equal(st_bundle["embeddings"][i], st_embeddings[i])
+    np.testing.assert_array_equal(enc_bundle["phonemes"], enc_phonemes)
+    np.testing.assert_array_equal(st_bundle["phonemes"], st_phonemes)
+    np.testing.assert_array_equal(np.isnan(enc_bundle["pitches"]), np.isnan(enc_pitches))
+    np.testing.assert_array_equal(enc_bundle["pitches"][~np.isnan(enc_pitches)], enc_pitches[~np.isnan(enc_pitches)])
+    np.testing.assert_array_equal(st_bundle["pitches"], st_pitches)
+    np.testing.assert_array_equal(enc_bundle["speakers"], np.array(["speaker-1", "speaker-1", "speaker-1"]))
+    np.testing.assert_array_equal(st_bundle["speakers"], np.array(["speaker-1", "speaker-1"]))

--- a/tests/test_collect_cache.py
+++ b/tests/test_collect_cache.py
@@ -1,0 +1,123 @@
+"""
+Tests for the NPZ cache helpers in encode/collect.py.
+
+Run: pytest tests/test_collect_cache.py -v
+
+Note: tests/test_load_alignments.py is a plain Python script (not pytest);
+migrating it is tracked separately.
+"""
+
+import numpy as np
+import pytest
+
+from encode.collect import NUM_LAYERS, _get_utterance_data, _load_cached, _save_cache
+
+
+def _make_embeddings(num_tokens: int = 3, embed_dim: int = 4) -> list:
+    return [np.random.rand(num_tokens, embed_dim).astype(np.float32) for _ in range(NUM_LAYERS)]
+
+
+def test_round_trip(tmp_path):
+    embeddings = _make_embeddings()
+    phonemes   = np.array(["AH", "B", "SIL"])
+    pitches    = np.array([120.0, np.nan, 200.0], dtype=np.float32)
+
+    _save_cache(tmp_path, "encodec", "utt-001", embeddings, phonemes, pitches)
+    result = _load_cached(tmp_path, "encodec", "utt-001")
+
+    assert result is not None
+    loaded_embeddings, loaded_phonemes, loaded_pitches = result
+    assert loaded_phonemes is not None
+    assert loaded_pitches is not None
+
+    for i in range(NUM_LAYERS):
+        np.testing.assert_array_equal(loaded_embeddings[i], embeddings[i])
+    np.testing.assert_array_equal(loaded_phonemes, phonemes)
+    np.testing.assert_array_equal(loaded_pitches[~np.isnan(pitches)],
+                                  pitches[~np.isnan(pitches)])
+    np.testing.assert_array_equal(np.isnan(loaded_pitches), np.isnan(pitches))
+
+
+def test_backward_compat(tmp_path):
+    embeddings = _make_embeddings()
+    npz_path = tmp_path / "encodec" / "utt-002.npz"
+    npz_path.parent.mkdir(parents=True)
+    np.savez(npz_path, **{f"layer_{i}": emb for i, emb in enumerate(embeddings)})
+
+    result = _load_cached(tmp_path, "encodec", "utt-002")
+
+    assert result is not None
+    loaded_embeddings, loaded_phonemes, loaded_pitches = result
+    for i in range(NUM_LAYERS):
+        np.testing.assert_array_equal(loaded_embeddings[i], embeddings[i])
+    assert loaded_phonemes is None
+    assert loaded_pitches is None
+
+
+def test_missing_file(tmp_path):
+    assert _load_cached(tmp_path, "encodec", "utt-999") is None
+
+
+def test_partial_cache_missing_pitches_loads_as_none(tmp_path):
+    embeddings = _make_embeddings()
+    phonemes = np.array(["AH", "B", "SIL"])
+    npz_path = tmp_path / "encodec" / "utt-003.npz"
+    npz_path.parent.mkdir(parents=True)
+    np.savez(
+        npz_path,
+        **{f"layer_{i}": emb for i, emb in enumerate(embeddings)},
+        phonemes=phonemes,
+    )
+
+    result = _load_cached(tmp_path, "encodec", "utt-003")
+
+    assert result is not None
+    loaded_embeddings, loaded_phonemes, loaded_pitches = result
+    for i in range(NUM_LAYERS):
+        np.testing.assert_array_equal(loaded_embeddings[i], embeddings[i])
+    np.testing.assert_array_equal(loaded_phonemes, phonemes)
+    assert loaded_pitches is None
+
+
+def test_get_utterance_data_backfills_missing_pitches(tmp_path, monkeypatch):
+    embeddings = _make_embeddings()
+    cached = (embeddings, np.array(["AH", "B", "SIL"]), None)
+    expected_phones = np.array(["AA", "BB", "CC"])
+    expected_pitches = np.array([101.0, np.nan, 205.0], dtype=np.float32)
+
+    def _fake_extract_features(*_args, **_kwargs):
+        return expected_phones, expected_pitches
+
+    monkeypatch.setattr("encode.collect._extract_features", _fake_extract_features)
+
+    result = _get_utterance_data(
+        "encodec",
+        cached,
+        tmp_path,
+        "utt-004",
+        encode_fn=None,
+        model=None,
+        audio=np.array([0.0], dtype=np.float32),
+        sr=16000,
+        phone_intervals=[],
+        token_rate=75.0,
+    )
+
+    assert result is not None
+    loaded_embeddings, loaded_phones, loaded_pitches = result
+    for i in range(NUM_LAYERS):
+        np.testing.assert_array_equal(loaded_embeddings[i], embeddings[i])
+    np.testing.assert_array_equal(loaded_phones, expected_phones)
+    np.testing.assert_array_equal(np.isnan(loaded_pitches), np.isnan(expected_pitches))
+    np.testing.assert_array_equal(
+        loaded_pitches[~np.isnan(expected_pitches)],
+        expected_pitches[~np.isnan(expected_pitches)],
+    )
+
+    cached_after = _load_cached(tmp_path, "encodec", "utt-004")
+    assert cached_after is not None
+    _, phones_after, pitches_after = cached_after
+    assert phones_after is not None
+    assert pitches_after is not None
+    np.testing.assert_array_equal(phones_after, expected_phones)
+    np.testing.assert_array_equal(np.isnan(pitches_after), np.isnan(expected_pitches))


### PR DESCRIPTION
Closes #6

## Changes

- Extends the NPZ cache schema to store `phonemes` and `pitches` alongside embeddings
- Fixes partial-cache bug: backfills missing phoneme or pitch data when only embeddings are cached
- Adds backward compatibility for old embeddings-only cache files (`phonemes`/`pitches` return `None`)
- Renames `Bundle` field `pitch` → `pitches` for consistency; updates all call sites in `main.py`
- Adds 5 tests covering round-trip, backward compat, missing file, partial cache, and backfill behavior
