### PR TITLE
Fix Hatch wheel package configuration for editable installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["data", "encode", "probe", "visualize"]
+
 # ── PyTorch must be installed separately (platform-specific index URL) ──────────
 #
 # macOS M4 (MPS support built into the default PyPI wheel):


### PR DESCRIPTION
## Summary

- add explicit Hatch wheel package configuration for the local project packages
- restore the documented `uv pip install -e .` setup flow

## Validation

- `uv pip install --python .venv/bin/python -e .`
- `.venv/bin/python -c "import data, encode, probe, visualize; print(\"imports-ok\")"`

Closes #13
