### PR TITLE
Clean up LibriSpeech ignore rules for current audio and alignment data paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,16 +222,11 @@ __marimo__/
 .claude/
 .claudeignore
 
-# LibriSpeech audio data (large binary files — never commit)
-LibriSpeech*/
-*.flac
-*.wav
-*.mp3
-
-# LibriSpeech alignment data (large, download separately)
-LibriSpeech-Alignments/
-LibriSpeech-Alignments.zip
-LibriSpeech.zip
+# LibriSpeech data artifacts (large, download separately)
+data/LibriSpeech/
+data/LibriSpeech.zip
+data/LibriSpeech-TextGrids/
+data/LibriSpeech-TextGrids.zip
 
 # Background literature PDFs (cite with links in README instead)
 BackgroundLiterature/


### PR DESCRIPTION
Closes #12 

## Summary
- replace stale LibriSpeech alignment ignore rules with current TextGrids paths under data/
- remove broad audio extension globs that could hide unrelated audio files
- keep archive ignores scoped to current LibriSpeech dataset artifacts

## Validation
- verified ignore behavior with git check-ignore for:
  - data/LibriSpeech
  - data/LibriSpeech.zip
  - data/LibriSpeech-TextGrids
  - data/LibriSpeech-TextGrids.zip
- confirmed obsolete LibriSpeech-Alignments patterns were removed
