### PR TITLE
Update README Python version guidance from 3.11 to 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ### 3. Create a virtual environment
 
 ```bash
-uv venv --python 3.11
+uv venv --python 3.12
 source .venv/bin/activate
 ```
 


### PR DESCRIPTION
Closes #11 

## Summary
- update README setup guidance to use Python 3.12 in the primary virtual environment command
- keep existing setup workflow and tooling instructions unchanged
- align documentation with the project baseline Python version

## Validation
- verified the setup command in README now uses `uv venv --python 3.12`
- verified no remaining `3.11` reference in README setup path
