### PR TITLE
Ignore SpeechTokenizer weights and checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,6 +228,10 @@ data/LibriSpeech.zip
 data/LibriSpeech-TextGrids/
 data/LibriSpeech-TextGrids.zip
 
+# SpeechTokenizer checkpoint files (download separately from SpeechTokenizer repo)
+data/SpeechTokenizer/
+data/SpeechTokenizer.zip
+
 # Background literature PDFs (cite with links in README instead)
 BackgroundLiterature/
 


### PR DESCRIPTION
## Summary
- Add ignore rules for SpeechTokenizer model weights and checkpoint artifacts
- Keep large generated assets out of version control to reduce repository noise

## Changes
- Update `.gitignore` to exclude SpeechTokenizer weight/checkpoint paths
