### PR TITLE
Validate data ingestion and deterministic train/eval split

### DIFF
--- a/data/_librispeech_layout.py
+++ b/data/_librispeech_layout.py
@@ -1,0 +1,55 @@
+"""
+Shared helpers for validating the LibriSpeech directory layout.
+
+Expected on-disk structure::
+
+    <root>/<split>/<speaker>/<chapter>/<speaker>-<chapter>-<utterance>.flac
+
+Both ``data.split`` and ``data.load_librispeech`` rely on this contract;
+keeping the checks in one place ensures both code paths stay in sync.
+"""
+
+from pathlib import Path
+from typing import Tuple
+
+
+def validate_librispeech_entry(flac_path: Path, split_dir: Path) -> Tuple[str, str, str]:
+    """Validate a single ``.flac`` path and return ``(speaker_id, chapter_id, utterance_id)``.
+
+    Parameters
+    ----------
+    flac_path:
+        Absolute path to the ``.flac`` file.
+    split_dir:
+        Root of the split directory (``<root>/<split>``).
+
+    Raises
+    ------
+    ValueError
+        If the path depth, filename format, or path/filename prefix mismatch
+        does not conform to the LibriSpeech layout.
+    """
+    rel_path = flac_path.relative_to(split_dir)
+    if len(rel_path.parts) != 3:
+        raise ValueError(
+            f"Malformed LibriSpeech path: {flac_path}. "
+            "Expected <split>/<speaker>/<chapter>/<utterance>.flac"
+        )
+
+    speaker_id = rel_path.parts[0]
+    chapter_id = rel_path.parts[1]
+
+    parts = flac_path.stem.split("-")
+    if len(parts) != 3:
+        raise ValueError(
+            f"Malformed LibriSpeech utterance filename: {flac_path.name}. "
+            "Expected <speaker>-<chapter>-<utterance>.flac"
+        )
+    if parts[0] != speaker_id or parts[1] != chapter_id:
+        raise ValueError(
+            f"LibriSpeech path/filename mismatch for {flac_path}: "
+            f"directory speaker/chapter is {speaker_id}/{chapter_id}, "
+            f"but filename starts with {parts[0]}/{parts[1]}"
+        )
+
+    return speaker_id, chapter_id, flac_path.stem

--- a/data/load_librispeech.py
+++ b/data/load_librispeech.py
@@ -44,7 +44,7 @@ def iter_librispeech(root: str, split: str = "train-clean-100") -> Iterator[Utte
         speaker_id = flac_path.parent.parent.name
         chapter_id = flac_path.parent.name
         parts = flac_path.stem.split("-")
-        if len(parts) < 3:
+        if len(parts) != 3:
             raise ValueError(
                 f"Malformed LibriSpeech utterance filename: {flac_path.name}. "
                 "Expected <speaker>-<chapter>-<utterance>.flac"

--- a/data/load_librispeech.py
+++ b/data/load_librispeech.py
@@ -11,6 +11,8 @@ from typing import Iterator
 import torch
 import torchaudio
 
+from data._librispeech_layout import validate_librispeech_entry
+
 
 @dataclass
 class Utterance:
@@ -30,32 +32,7 @@ def iter_librispeech(root: str, split: str = "train-clean-100") -> Iterator[Utte
         raise NotADirectoryError(f"LibriSpeech split is not a directory: {split_dir}")
 
     for flac_path in sorted(split_dir.rglob("*.flac")):
-        try:
-            relative_path = flac_path.relative_to(split_dir)
-        except ValueError:
-            raise ValueError(f"Found file outside split directory: {flac_path}")
-
-        if len(relative_path.parts) != 3:
-            raise ValueError(
-                f"Malformed LibriSpeech path: {flac_path}. "
-                "Expected <split>/<speaker>/<chapter>/<utterance>.flac"
-            )
-
-        speaker_id = flac_path.parent.parent.name
-        chapter_id = flac_path.parent.name
-        parts = flac_path.stem.split("-")
-        if len(parts) != 3:
-            raise ValueError(
-                f"Malformed LibriSpeech utterance filename: {flac_path.name}. "
-                "Expected <speaker>-<chapter>-<utterance>.flac"
-            )
-        if parts[0] != speaker_id or parts[1] != chapter_id:
-            raise ValueError(
-                f"LibriSpeech path/filename mismatch for {flac_path}: "
-                f"directory speaker/chapter is {speaker_id}/{chapter_id}, "
-                f"but filename starts with {parts[0]}/{parts[1]}"
-            )
-        utterance_id = flac_path.stem
+        speaker_id, _chapter_id, utterance_id = validate_librispeech_entry(flac_path, split_dir)
 
         try:
             audio, sr = torchaudio.load(str(flac_path))

--- a/data/load_librispeech.py
+++ b/data/load_librispeech.py
@@ -26,13 +26,24 @@ def iter_librispeech(root: str, split: str = "train-clean-100") -> Iterator[Utte
     split_dir = Path(root) / split
     if not split_dir.exists():
         raise FileNotFoundError(f"LibriSpeech split not found at {split_dir}")
+    if not split_dir.is_dir():
+        raise NotADirectoryError(f"LibriSpeech split is not a directory: {split_dir}")
 
     for flac_path in sorted(split_dir.rglob("*.flac")):
         parts = flac_path.stem.split("-")
+        if len(parts) < 3:
+            raise ValueError(
+                f"Malformed LibriSpeech utterance filename: {flac_path.name}. "
+                "Expected <speaker>-<chapter>-<utterance>.flac"
+            )
         speaker_id = parts[0]
         utterance_id = flac_path.stem
 
-        audio, sr = torchaudio.load(str(flac_path))
+        try:
+            audio, sr = torchaudio.load(str(flac_path))
+        except Exception as e:  # pragma: no cover - defensive context wrapper
+            raise RuntimeError(f"Failed to load audio file {flac_path}: {e}") from e
+
         yield Utterance(
             audio=audio,
             sample_rate=sr,

--- a/data/load_librispeech.py
+++ b/data/load_librispeech.py
@@ -30,13 +30,31 @@ def iter_librispeech(root: str, split: str = "train-clean-100") -> Iterator[Utte
         raise NotADirectoryError(f"LibriSpeech split is not a directory: {split_dir}")
 
     for flac_path in sorted(split_dir.rglob("*.flac")):
+        try:
+            relative_path = flac_path.relative_to(split_dir)
+        except ValueError:
+            raise ValueError(f"Found file outside split directory: {flac_path}")
+
+        if len(relative_path.parts) != 3:
+            raise ValueError(
+                f"Malformed LibriSpeech path: {flac_path}. "
+                "Expected <split>/<speaker>/<chapter>/<utterance>.flac"
+            )
+
+        speaker_id = flac_path.parent.parent.name
+        chapter_id = flac_path.parent.name
         parts = flac_path.stem.split("-")
         if len(parts) < 3:
             raise ValueError(
                 f"Malformed LibriSpeech utterance filename: {flac_path.name}. "
                 "Expected <speaker>-<chapter>-<utterance>.flac"
             )
-        speaker_id = parts[0]
+        if parts[0] != speaker_id or parts[1] != chapter_id:
+            raise ValueError(
+                f"LibriSpeech path/filename mismatch for {flac_path}: "
+                f"directory speaker/chapter is {speaker_id}/{chapter_id}, "
+                f"but filename starts with {parts[0]}/{parts[1]}"
+            )
         utterance_id = flac_path.stem
 
         try:

--- a/data/split.py
+++ b/data/split.py
@@ -11,6 +11,8 @@ from json import JSONDecodeError
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+from data._librispeech_layout import validate_librispeech_entry
+
 import numpy as np
 
 # (flac_path, speaker_id, utterance_id)
@@ -28,29 +30,7 @@ def scan_utterance_paths(librispeech_root: str, split: str) -> List[UttEntry]:
     entries: List[UttEntry] = []
 
     for flac_path in split_root.rglob("*.flac"):
-        rel_path = flac_path.relative_to(split_root)
-        if len(rel_path.parts) != 3:
-            raise ValueError(
-                f"Malformed LibriSpeech path: {flac_path}. "
-                "Expected <split>/<speaker>/<chapter>/<utterance>.flac"
-            )
-
-        speaker_id = rel_path.parts[0]
-        chapter_id = rel_path.parts[1]
-        parts = flac_path.stem.split("-")
-        if len(parts) != 3:
-            raise ValueError(
-                f"Malformed LibriSpeech utterance filename: {flac_path.name}. "
-                "Expected <speaker>-<chapter>-<utterance>.flac"
-            )
-        if parts[0] != speaker_id or parts[1] != chapter_id:
-            raise ValueError(
-                f"LibriSpeech path/filename mismatch for {flac_path}: "
-                f"directory speaker/chapter is {speaker_id}/{chapter_id}, "
-                f"but filename starts with {parts[0]}/{parts[1]}"
-            )
-
-        utterance_id = flac_path.stem
+        speaker_id, _chapter_id, utterance_id = validate_librispeech_entry(flac_path, split_root)
         entries.append((str(flac_path), speaker_id, utterance_id))
     entries.sort(key=lambda x: x[2])   # deterministic order by utterance ID
     return entries
@@ -116,7 +96,8 @@ def split_utterances(
             raise ValueError(
                 "Invalid split JSON at "
                 f"{save_path}: cached IDs do not match current entries "
-                f"(missing={len(missing_ids)}, unknown={len(unknown_ids)})"
+                f"(missing={len(missing_ids)}, unknown={len(unknown_ids)}). "
+                "Re-run with force=True (--force_resplit) to recompute the split."
             )
 
         train = [by_id[uid] for uid in saved["train"]]

--- a/data/split.py
+++ b/data/split.py
@@ -29,7 +29,27 @@ def scan_utterance_paths(librispeech_root: str, split: str) -> List[UttEntry]:
 
     for flac_path in split_root.rglob("*.flac"):
         rel_path = flac_path.relative_to(split_root)
+        if len(rel_path.parts) != 3:
+            raise ValueError(
+                f"Malformed LibriSpeech path: {flac_path}. "
+                "Expected <split>/<speaker>/<chapter>/<utterance>.flac"
+            )
+
         speaker_id = rel_path.parts[0]
+        chapter_id = rel_path.parts[1]
+        parts = flac_path.stem.split("-")
+        if len(parts) != 3:
+            raise ValueError(
+                f"Malformed LibriSpeech utterance filename: {flac_path.name}. "
+                "Expected <speaker>-<chapter>-<utterance>.flac"
+            )
+        if parts[0] != speaker_id or parts[1] != chapter_id:
+            raise ValueError(
+                f"LibriSpeech path/filename mismatch for {flac_path}: "
+                f"directory speaker/chapter is {speaker_id}/{chapter_id}, "
+                f"but filename starts with {parts[0]}/{parts[1]}"
+            )
+
         utterance_id = flac_path.stem
         entries.append((str(flac_path), speaker_id, utterance_id))
     entries.sort(key=lambda x: x[2])   # deterministic order by utterance ID
@@ -68,6 +88,19 @@ def split_utterances(
             raise ValueError(
                 f"Invalid split JSON at {save_path}: 'train' and 'eval' must be lists"
             )
+
+        for uid in saved["train"] + saved["eval"]:
+            if not isinstance(uid, str):
+                raise ValueError(
+                    f"Invalid split JSON at {save_path}: all utterance IDs must be strings"
+                )
+
+        combined = saved["train"] + saved["eval"]
+        if len(combined) != len(set(combined)):
+            raise ValueError(
+                f"Invalid split JSON at {save_path}: utterance IDs must be unique"
+            )
+
         overlap = set(saved["train"]) & set(saved["eval"])
         if overlap:
             raise ValueError(
@@ -75,8 +108,19 @@ def split_utterances(
             )
 
         by_id = {e[2]: e for e in entries}
-        train = [by_id[uid] for uid in saved["train"] if uid in by_id]
-        eval_ = [by_id[uid] for uid in saved["eval"]  if uid in by_id]
+        saved_ids = set(saved["train"]) | set(saved["eval"])
+        current_ids = set(by_id.keys())
+        missing_ids = sorted(current_ids - saved_ids)
+        unknown_ids = sorted(saved_ids - current_ids)
+        if missing_ids or unknown_ids:
+            raise ValueError(
+                "Invalid split JSON at "
+                f"{save_path}: cached IDs do not match current entries "
+                f"(missing={len(missing_ids)}, unknown={len(unknown_ids)})"
+            )
+
+        train = [by_id[uid] for uid in saved["train"]]
+        eval_ = [by_id[uid] for uid in saved["eval"]]
         print(f"Loaded split from {save_path}  (train={len(train)}, eval={len(eval_)})")
         return train, eval_
 

--- a/data/split.py
+++ b/data/split.py
@@ -7,6 +7,7 @@ runs so the exact same utterances are always in train vs eval.
 
 import json
 from collections import defaultdict
+from json import JSONDecodeError
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -53,8 +54,21 @@ def split_utterances(
         raise ValueError(f"eval_frac must be in [0, 1), current value: {eval_frac}")
 
     if save_path.exists() and not force:
-        with open(save_path) as f:
-            saved = json.load(f)
+        try:
+            with open(save_path) as f:
+                saved = json.load(f)
+        except JSONDecodeError as e:
+            raise ValueError(f"Malformed split JSON at {save_path}: {e}") from e
+
+        if not isinstance(saved, dict) or "train" not in saved or "eval" not in saved:
+            raise ValueError(
+                f"Invalid split JSON at {save_path}: expected keys 'train' and 'eval'"
+            )
+        if not isinstance(saved["train"], list) or not isinstance(saved["eval"], list):
+            raise ValueError(
+                f"Invalid split JSON at {save_path}: 'train' and 'eval' must be lists"
+            )
+
         by_id = {e[2]: e for e in entries}
         train = [by_id[uid] for uid in saved["train"] if uid in by_id]
         eval_ = [by_id[uid] for uid in saved["eval"]  if uid in by_id]
@@ -75,7 +89,7 @@ def split_utterances(
         n_utt = len(shuffled)
         # Keep approximately eval_frac in eval while preserving at least one
         # training utterance for speakers that have multiple utterances.
-        if n_utt <= 1:
+        if n_utt <= 1 or eval_frac == 0.0:
             n_eval = 0
         else:
             n_eval = max(1, round(n_utt * eval_frac))

--- a/data/split.py
+++ b/data/split.py
@@ -68,6 +68,11 @@ def split_utterances(
             raise ValueError(
                 f"Invalid split JSON at {save_path}: 'train' and 'eval' must be lists"
             )
+        overlap = set(saved["train"]) & set(saved["eval"])
+        if overlap:
+            raise ValueError(
+                f"Invalid split JSON at {save_path}: 'train' and 'eval' must be disjoint"
+            )
 
         by_id = {e[2]: e for e in entries}
         train = [by_id[uid] for uid in saved["train"] if uid in by_id]

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 import pytest
 import torch
@@ -265,7 +266,7 @@ def test_iter_librispeech_load_failure_has_context(tmp_path, monkeypatch):
 
     monkeypatch.setattr("data.load_librispeech.torchaudio.load", fake_load)
 
-    with pytest.raises(RuntimeError, match=f"{failing_path}"):
+    with pytest.raises(RuntimeError, match=re.escape(str(failing_path))):
         list(iter_librispeech(str(tmp_path), "train-clean-100"))
 
 
@@ -286,3 +287,82 @@ def test_scan_split_pipeline_consistency(tmp_path):
     assert len(entries) == 10
     assert len(train) + len(eval_) == 10
     assert set(e[2] for e in train).isdisjoint(set(e[2] for e in eval_))
+
+
+# ---------------------------------------------------------------------------
+# scan_utterance_paths - wrong directory depth
+# ---------------------------------------------------------------------------
+
+def test_scan_utterance_paths_wrong_depth_raises(tmp_path):
+    # File nested one level too deep (4 parts instead of 3)
+    split_root = tmp_path / "train-clean-100"
+    _touch(split_root / "100" / "001" / "extra" / "100-001-0001.flac")
+
+    with pytest.raises(ValueError, match="Malformed LibriSpeech path"):
+        scan_utterance_paths(str(tmp_path), "train-clean-100")
+
+
+# ---------------------------------------------------------------------------
+# split_utterances cache - non-string IDs and overlapping IDs
+# ---------------------------------------------------------------------------
+
+def test_split_utterances_non_string_id_in_cache_raises(tmp_path):
+    entries = [("/fake/100-001-0001.flac", "100", "100-001-0001")]
+    save_path = tmp_path / "split.json"
+    save_path.write_text(
+        json.dumps({"train": [42], "eval": []}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="all utterance IDs must be strings"):
+        split_utterances(entries, eval_frac=0.2, seed=1, save_path=save_path)
+
+
+def test_split_utterances_overlapping_ids_in_cache_raises(tmp_path):
+    entries = [
+        ("/fake/100-001-0001.flac", "100", "100-001-0001"),
+        ("/fake/100-001-0002.flac", "100", "100-001-0002"),
+    ]
+    save_path = tmp_path / "split.json"
+    save_path.write_text(
+        json.dumps({"train": ["100-001-0001"], "eval": ["100-001-0001", "100-001-0002"]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="utterance IDs must be unique"):
+        split_utterances(entries, eval_frac=0.2, seed=1, save_path=save_path)
+
+
+def test_split_utterances_stale_cache_error_mentions_force(tmp_path):
+    entries = [
+        ("/fake/100-001-0001.flac", "100", "100-001-0001"),
+        ("/fake/100-001-0002.flac", "100", "100-001-0002"),
+    ]
+    save_path = tmp_path / "split.json"
+    save_path.write_text(
+        json.dumps({"train": ["100-001-0001"], "eval": ["stale-uid"]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="force"):
+        split_utterances(entries, eval_frac=0.2, seed=1, save_path=save_path)
+
+
+# ---------------------------------------------------------------------------
+# iter_librispeech - wrong depth and path/filename mismatch
+# ---------------------------------------------------------------------------
+
+def test_iter_librispeech_wrong_depth_raises(tmp_path):
+    split_root = tmp_path / "train-clean-100"
+    _touch(split_root / "123" / "456" / "extra" / "123-456-0001.flac")
+
+    with pytest.raises(ValueError, match="Malformed LibriSpeech path"):
+        list(iter_librispeech(str(tmp_path), "train-clean-100"))
+
+
+def test_iter_librispeech_path_filename_mismatch_raises(tmp_path):
+    split_root = tmp_path / "train-clean-100"
+    _touch(split_root / "123" / "456" / "999-456-0001.flac")
+
+    with pytest.raises(ValueError, match="path/filename mismatch"):
+        list(iter_librispeech(str(tmp_path), "train-clean-100"))

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,0 +1,239 @@
+import json
+
+import pytest
+import torch
+
+from data.load_librispeech import iter_librispeech
+from data.split import scan_utterance_paths, split_utterances
+
+
+def _touch(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+
+
+def test_scan_utterance_paths_sorted_and_speaker_extracted(tmp_path):
+    split_root = tmp_path / "train-clean-100"
+    _touch(split_root / "100" / "001" / "100-001-0003.flac")
+    _touch(split_root / "100" / "001" / "100-001-0001.flac")
+    _touch(split_root / "200" / "007" / "200-007-0001.flac")
+
+    entries = scan_utterance_paths(str(tmp_path), "train-clean-100")
+
+    assert [e[2] for e in entries] == ["100-001-0001", "100-001-0003", "200-007-0001"]
+    assert [e[1] for e in entries] == ["100", "100", "200"]
+
+
+def test_scan_utterance_paths_missing_split_raises(tmp_path):
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        scan_utterance_paths(str(tmp_path), "missing-split")
+
+
+def test_scan_utterance_paths_not_directory_raises(tmp_path):
+    split_file = tmp_path / "train-clean-100"
+    split_file.touch()
+
+    with pytest.raises(NotADirectoryError, match="not a directory"):
+        scan_utterance_paths(str(tmp_path), "train-clean-100")
+
+
+def test_split_utterances_deterministic_no_overlap_and_conservation(tmp_path):
+    entries = []
+    for speaker in ["100", "200", "300"]:
+        for i in range(10):
+            uid = f"{speaker}-001-{i:04d}"
+            entries.append((f"/fake/{uid}.flac", speaker, uid))
+
+    save_path_1 = tmp_path / "split_a.json"
+    train_1, eval_1 = split_utterances(entries, eval_frac=0.2, seed=42, save_path=save_path_1)
+
+    save_path_2 = tmp_path / "split_b.json"
+    train_2, eval_2 = split_utterances(entries, eval_frac=0.2, seed=42, save_path=save_path_2)
+
+    train_uids_1 = [e[2] for e in train_1]
+    eval_uids_1 = [e[2] for e in eval_1]
+    train_uids_2 = [e[2] for e in train_2]
+    eval_uids_2 = [e[2] for e in eval_2]
+
+    assert train_uids_1 == train_uids_2
+    assert eval_uids_1 == eval_uids_2
+
+    train_set = set(train_uids_1)
+    eval_set = set(eval_uids_1)
+    all_set = {e[2] for e in entries}
+
+    assert train_set.isdisjoint(eval_set)
+    assert train_set.union(eval_set) == all_set
+
+
+def test_split_utterances_speaker_distribution_within_tolerance(tmp_path):
+    entries = []
+    for speaker in ["100", "200"]:
+        for i in range(20):
+            uid = f"{speaker}-001-{i:04d}"
+            entries.append((f"/fake/{uid}.flac", speaker, uid))
+
+    train, eval_ = split_utterances(
+        entries,
+        eval_frac=0.2,
+        seed=123,
+        save_path=tmp_path / "split.json",
+    )
+
+    for speaker in ["100", "200"]:
+        total = sum(1 for _, spk, _ in entries if spk == speaker)
+        eval_count = sum(1 for _, spk, _ in eval_ if spk == speaker)
+        observed = eval_count / total
+        assert abs(observed - 0.2) <= 0.1
+
+    assert len(train) + len(eval_) == len(entries)
+
+
+def test_split_utterances_single_utterance_speaker_stays_in_train(tmp_path):
+    entries = [
+        ("/fake/100-001-0001.flac", "100", "100-001-0001"),
+        ("/fake/200-001-0001.flac", "200", "200-001-0001"),
+        ("/fake/300-001-0001.flac", "300", "300-001-0001"),
+        ("/fake/300-001-0002.flac", "300", "300-001-0002"),
+    ]
+
+    train, eval_ = split_utterances(
+        entries,
+        eval_frac=0.5,
+        seed=7,
+        save_path=tmp_path / "split.json",
+    )
+
+    train_uids = {e[2] for e in train}
+    eval_uids = {e[2] for e in eval_}
+
+    assert "100-001-0001" in train_uids
+    assert "200-001-0001" in train_uids
+    assert "100-001-0001" not in eval_uids
+    assert "200-001-0001" not in eval_uids
+
+
+def test_split_utterances_eval_frac_zero(tmp_path):
+    entries = [(f"/fake/100-001-{i:04d}.flac", "100", f"100-001-{i:04d}") for i in range(8)]
+
+    train, eval_ = split_utterances(
+        entries,
+        eval_frac=0.0,
+        seed=5,
+        save_path=tmp_path / "split.json",
+    )
+
+    assert len(train) == len(entries)
+    assert len(eval_) == 0
+
+
+def test_split_utterances_eval_frac_out_of_bounds(tmp_path):
+    entries = [("/fake/100-001-0001.flac", "100", "100-001-0001")]
+
+    with pytest.raises(ValueError, match=r"must be in \[0, 1\)"):
+        split_utterances(entries, eval_frac=-0.1, seed=0, save_path=tmp_path / "neg.json")
+
+    with pytest.raises(ValueError, match=r"must be in \[0, 1\)"):
+        split_utterances(entries, eval_frac=1.0, seed=0, save_path=tmp_path / "one.json")
+
+
+def test_split_utterances_reload_and_force_behavior(tmp_path):
+    entries = [(f"/fake/100-001-{i:04d}.flac", "100", f"100-001-{i:04d}") for i in range(20)]
+    save_path = tmp_path / "split.json"
+
+    train_a, eval_a = split_utterances(entries, eval_frac=0.1, seed=42, save_path=save_path)
+    train_b, eval_b = split_utterances(entries, eval_frac=0.4, seed=42, save_path=save_path, force=False)
+
+    assert [e[2] for e in train_a] == [e[2] for e in train_b]
+    assert [e[2] for e in eval_a] == [e[2] for e in eval_b]
+
+    train_c, eval_c = split_utterances(entries, eval_frac=0.4, seed=42, save_path=save_path, force=True)
+    assert len(eval_c) > len(eval_a)
+    assert len(train_c) < len(train_a)
+
+
+def test_split_utterances_malformed_saved_json_raises(tmp_path):
+    entries = [("/fake/100-001-0001.flac", "100", "100-001-0001")]
+    save_path = tmp_path / "split.json"
+    save_path.write_text("{ malformed json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Malformed split JSON"):
+        split_utterances(entries, eval_frac=0.2, seed=1, save_path=save_path)
+
+
+def test_split_utterances_missing_json_keys_raises(tmp_path):
+    entries = [("/fake/100-001-0001.flac", "100", "100-001-0001")]
+    save_path = tmp_path / "split.json"
+    save_path.write_text(json.dumps({"train": []}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="expected keys 'train' and 'eval'"):
+        split_utterances(entries, eval_frac=0.2, seed=1, save_path=save_path)
+
+
+def test_iter_librispeech_yields_expected_fields(tmp_path, monkeypatch):
+    split_root = tmp_path / "train-clean-100"
+    _touch(split_root / "123" / "456" / "123-456-0001.flac")
+
+    def fake_load(_path):
+        return torch.zeros((1, 1600), dtype=torch.float32), 16000
+
+    monkeypatch.setattr("data.load_librispeech.torchaudio.load", fake_load)
+
+    utterances = list(iter_librispeech(str(tmp_path), "train-clean-100"))
+
+    assert len(utterances) == 1
+    u = utterances[0]
+    assert u.speaker_id == "123"
+    assert u.utterance_id == "123-456-0001"
+    assert u.sample_rate == 16000
+    assert tuple(u.audio.shape) == (1, 1600)
+
+
+def test_iter_librispeech_missing_split_raises(tmp_path):
+    with pytest.raises(FileNotFoundError, match="split not found"):
+        list(iter_librispeech(str(tmp_path), "missing"))
+
+
+def test_iter_librispeech_malformed_filename_raises(tmp_path, monkeypatch):
+    split_root = tmp_path / "train-clean-100"
+    _touch(split_root / "123" / "456" / "badname.flac")
+
+    def fake_load(_path):
+        return torch.zeros((1, 1600), dtype=torch.float32), 16000
+
+    monkeypatch.setattr("data.load_librispeech.torchaudio.load", fake_load)
+
+    with pytest.raises(ValueError, match="Malformed LibriSpeech utterance filename"):
+        list(iter_librispeech(str(tmp_path), "train-clean-100"))
+
+
+def test_iter_librispeech_load_failure_has_context(tmp_path, monkeypatch):
+    split_root = tmp_path / "train-clean-100"
+    _touch(split_root / "123" / "456" / "123-456-0001.flac")
+
+    def fake_load(_path):
+        raise OSError("decode failure")
+
+    monkeypatch.setattr("data.load_librispeech.torchaudio.load", fake_load)
+
+    with pytest.raises(RuntimeError, match="Failed to load audio file"):
+        list(iter_librispeech(str(tmp_path), "train-clean-100"))
+
+
+def test_scan_split_pipeline_consistency(tmp_path):
+    split_root = tmp_path / "train-clean-100"
+    for speaker in ["100", "200"]:
+        for i in range(5):
+            _touch(split_root / speaker / "001" / f"{speaker}-001-{i:04d}.flac")
+
+    entries = scan_utterance_paths(str(tmp_path), "train-clean-100")
+    train, eval_ = split_utterances(
+        entries,
+        eval_frac=0.3,
+        seed=11,
+        save_path=tmp_path / "split.json",
+    )
+
+    assert len(entries) == 10
+    assert len(train) + len(eval_) == 10
+    assert set(e[2] for e in train).isdisjoint(set(e[2] for e in eval_))

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -37,6 +37,22 @@ def test_scan_utterance_paths_not_directory_raises(tmp_path):
         scan_utterance_paths(str(tmp_path), "train-clean-100")
 
 
+def test_scan_utterance_paths_filename_must_match_expected_format(tmp_path):
+    split_root = tmp_path / "train-clean-100"
+    _touch(split_root / "100" / "001" / "100-001-0001-extra.flac")
+
+    with pytest.raises(ValueError, match="Malformed LibriSpeech utterance filename"):
+        scan_utterance_paths(str(tmp_path), "train-clean-100")
+
+
+def test_scan_utterance_paths_path_filename_mismatch_raises(tmp_path):
+    split_root = tmp_path / "train-clean-100"
+    _touch(split_root / "100" / "001" / "999-001-0001.flac")
+
+    with pytest.raises(ValueError, match="path/filename mismatch"):
+        scan_utterance_paths(str(tmp_path), "train-clean-100")
+
+
 def test_split_utterances_deterministic_no_overlap_and_conservation(tmp_path):
     entries = []
     for speaker in ["100", "200", "300"]:
@@ -170,6 +186,30 @@ def test_split_utterances_missing_json_keys_raises(tmp_path):
         split_utterances(entries, eval_frac=0.2, seed=1, save_path=save_path)
 
 
+def test_split_utterances_non_list_json_values_raises(tmp_path):
+    entries = [("/fake/100-001-0001.flac", "100", "100-001-0001")]
+    save_path = tmp_path / "split.json"
+    save_path.write_text(json.dumps({"train": "100-001-0001", "eval": []}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must be lists"):
+        split_utterances(entries, eval_frac=0.2, seed=1, save_path=save_path)
+
+
+def test_split_utterances_cached_ids_must_match_current_entries(tmp_path):
+    entries = [
+        ("/fake/100-001-0001.flac", "100", "100-001-0001"),
+        ("/fake/100-001-0002.flac", "100", "100-001-0002"),
+    ]
+    save_path = tmp_path / "split.json"
+    save_path.write_text(
+        json.dumps({"train": ["100-001-0001"], "eval": ["unknown-uid"]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="cached IDs do not match current entries"):
+        split_utterances(entries, eval_frac=0.2, seed=1, save_path=save_path)
+
+
 def test_iter_librispeech_yields_expected_fields(tmp_path, monkeypatch):
     split_root = tmp_path / "train-clean-100"
     _touch(split_root / "123" / "456" / "123-456-0001.flac")
@@ -194,9 +234,17 @@ def test_iter_librispeech_missing_split_raises(tmp_path):
         list(iter_librispeech(str(tmp_path), "missing"))
 
 
+def test_iter_librispeech_split_not_directory_raises(tmp_path):
+    split_path = tmp_path / "train-clean-100"
+    split_path.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(NotADirectoryError, match="not a directory"):
+        list(iter_librispeech(str(tmp_path), "train-clean-100"))
+
+
 def test_iter_librispeech_malformed_filename_raises(tmp_path, monkeypatch):
     split_root = tmp_path / "train-clean-100"
-    _touch(split_root / "123" / "456" / "badname.flac")
+    _touch(split_root / "123" / "456" / "123-456-0001-extra.flac")
 
     def fake_load(_path):
         return torch.zeros((1, 1600), dtype=torch.float32), 16000
@@ -209,14 +257,15 @@ def test_iter_librispeech_malformed_filename_raises(tmp_path, monkeypatch):
 
 def test_iter_librispeech_load_failure_has_context(tmp_path, monkeypatch):
     split_root = tmp_path / "train-clean-100"
-    _touch(split_root / "123" / "456" / "123-456-0001.flac")
+    failing_path = split_root / "123" / "456" / "123-456-0001.flac"
+    _touch(failing_path)
 
     def fake_load(_path):
         raise OSError("decode failure")
 
     monkeypatch.setattr("data.load_librispeech.torchaudio.load", fake_load)
 
-    with pytest.raises(RuntimeError, match="Failed to load audio file"):
+    with pytest.raises(RuntimeError, match=f"{failing_path}"):
         list(iter_librispeech(str(tmp_path), "train-clean-100"))
 
 


### PR DESCRIPTION
## Summary

Adds automated validation for issue #17 across LibriSpeech ingestion and deterministic train/eval splitting.

## What Changed

- Added new test module `tests/test_split.py` covering:
  - `scan_utterance_paths()` discovery, ordering, and split-path errors
  - `split_utterances()` determinism, disjointness, conservation, bounds, reload/force behavior
  - `iter_librispeech()` success path and actionable failure behavior
  - scan+split consistency integration check
- Hardened split cache loading in `data/split.py`:
  - malformed JSON now raises a clear `ValueError`
  - missing required keys/types now raises a clear `ValueError`
  - fixed `eval_frac=0.0` so all utterances remain in train
- Hardened ingestion in `data/load_librispeech.py`:
  - validates split path is a directory
  - validates expected utterance filename format
  - wraps audio load errors with file-specific context

## Validation

- Ran: `.venv/bin/python -m pytest tests/test_split.py -v`
- Ran: `.venv/bin/python -m pytest tests -v`
- Result: all tests passed.

Closes #17
